### PR TITLE
refactor barcode testing to use parameterization for easier addition

### DIFF
--- a/test/test_barcodes.py
+++ b/test/test_barcodes.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 '''
 unit tests for barcodes.py
 '''
@@ -8,21 +7,45 @@ import pytest
 from caravan import barcodes
 from Bio import SeqIO
 
+
 @pytest.fixture
-def mapper(tmpdir):
-    barcode_map = {'AACCGGTT': 'sample1'}
-    fastq = tmpdir.join("for.fq")
-    fastq.write('@header#ACGT/1\nAACCGGTT\n+\naaaaaaaa\n')
+def fastq_contents(request, tmpdir, scope='function'):
+    'take fastq contents and make a temp file, parse with SeqIO, return iterator'
+    fastq = tmpdir.join('for.fq')
+    fastq.write(request.param)
     fastq_fh = fastq.open()
     fastq_records = SeqIO.parse(fastq_fh, 'fastq')
-    max_diffs = 0
-    mr = barcodes.MappedRecords(barcode_map, fastq_records, max_diffs)
-    return mr
+    return fastq_records
 
 
-class TestMapper:
-    def test_correct(self, mapper):
-        assert next(mapper) == 'header#ACGT/1\tsample1\n'
+class TestMappedRecords:
+    @pytest.mark.parametrize('barcode_map, fastq_contents, max_diffs, expected', [
+        ({'AACCGGTT': 'sample1'}, '@header#ACGT/1\nAACCGGTT\n+\naaaaaaaa\n', 0, 'header#ACGT/1\tsample1\n'),
+        ({'AACCGGTT': 'sample1'}, '@header#ACGT/1\nAACCGGGT\n+\naaaaaaaa\n', 1, 'header#ACGT/1\tsample1\n')
+    ], indirect=['fastq_contents'])
+    def test_correct(self, barcode_map, fastq_contents, max_diffs, expected):
+        'barcode in fastq matches with barcode_map with specified differences'
+        mapped_records = barcodes.MappedRecords(barcode_map, fastq_contents, max_diffs)
+        assert next(mapped_records) == expected
+
+    @pytest.mark.parametrize('barcode_map, fastq_contents, max_diffs', [
+        ({'AACCGGTT': 'sample1'}, '@header#ACGT/1\nTTCCGGTT\n+\naaaaaaaa\n', 1),
+        ({'GGAATTCC': 'sample1'}, '@header#ACGT/1\nAACCGGGT\n+\naaaaaaaa\n', 0)
+    ], indirect=['fastq_contents'])
+    def test_no_match(self, barcode_map, fastq_contents, max_diffs):
+        'barcode in fastq does not match map with specified maxdiffs'
+        with pytest.raises(StopIteration):
+            mapped_records = barcodes.MappedRecords(barcode_map, fastq_contents, max_diffs)
+            next(mapped_records)
+
+    @pytest.mark.parametrize('barcode_map, fastq_contents, max_diffs', [
+        ({'AACCGGTT': 'sample1'}, '@header#ACGT/1\nTTCCGGTT\n+\naaaaaaaa\n@header#ACGT/2\nTTCCGGTT\n+\naaaaaaaa\n', 1)
+    ], indirect=['fastq_contents'])
+    def test_bad_barcodes_cached(self, barcode_map, fastq_contents, max_diffs):
+        'repeated bad barcode doesnt test distance again'
+        with pytest.raises(StopIteration):
+            mapped_records = barcodes.MappedRecords(barcode_map, fastq_contents, max_diffs)
+            next(mapped_records)
 
 
 class TestHammingDistance:


### PR DESCRIPTION
Learning how test parametrization works, and the power/use of fixtures.

Tests can take parameters if you use the `mark.parametrize` decorator. This makes it easy to run the same test with different arguments.

 If you need to preprocess a parameter with some common boilerplate, you can use the `indirect=` parameter and that argument will be passed to a fixture of the same name.That variable will become whatever the fixture returns or yields for the test. This seems useful for when you need to spoof a file, or connect to a db, or anything that requires some "setup" and "teardown" that would clutter your test.
